### PR TITLE
Get basic Heroku support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+venv
 eggs
 parts
 bin

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn gettingstarted.wsgi --log-file -

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn gettingstarted.wsgi --log-file -
+web: gunicorn website.wsgi --log-file -

--- a/README.md
+++ b/README.md
@@ -21,28 +21,38 @@ You need to have installed on your local machine
 * Django and other Python libraries
 
 On a Debian- or Ubuntu-based system, it may suffice (untested) to run
+```
   $ sudo apt-get install git-core python-django python-django-south python-simplejson
+```
+
 
 On Mac OS, the easiest way may be to install pip:
   http://www.pip-installer.org/en/latest/installing.html
 and then
+```
   $ pip install Django
+```
 
 
 Initial setup
 -------------
 
+```
   $ python website/manage.py syncdb && python website/manage.py migrate
   $ mkdir articles
+```
 
 
 Running NewsDiffs Locally
 -------------------------
 
 Do the initial setup above.  Then to start the webserver for testing:
-  $ python website/manage.py runserver
 
-and visit http://localhost:8000/
+```
+  $ python website/manage.py runserver
+```
+
+and visit `http://localhost:8000/`
 
 
 Running the scraper
@@ -51,19 +61,25 @@ Running the scraper
 Do the initial setup above.  You will also need additional Python
 libraries; on a Debian- or Ubuntu-based system, it may suffice
 (untested) to run
+```
   $ sudo apt-get install python-bs4 python-beautifulsoup
+```
 
 on a Mac, you will want something like
 
+```
  $ pip install beautifulsoup4
  $ pip install beautifulsoup
  $ pip install html5lib
+```
 
 Note that we need two versions of BeautifulSoup, both 3.2 and 4.0;
 some websites are parsed correctly in only one version.
 
 Then run
+```
   $ python website/manage.py scraper
+```
 
 This will populate the articles repository with a list of current news
 articles.  This is a snapshot at a single time, so the website will
@@ -78,7 +94,9 @@ is cumulative).
 
 To run the scraper every hour, run something like:
 
+```
  $ while true; do python website/manage.py scraper; sleep 60m; done
+```
 
 or make a cron job.
 
@@ -88,20 +106,24 @@ Adding new sites to the scraper
 The procedure for adding new sites to the scraper is outlined in
 parsers/__init__.py .  You need to
 
-  (1) Create a new parser module in parsers/ .  This should be a
-      subclass of BaseParser (in parsers/baseparser.py).  Model it off
-      the other parsers in that directory.  You can test the parser
-      with by running, e.g.,
+1. Create a new parser module in parsers/ .  This should be a
+   subclass of BaseParser (in parsers/baseparser.py).  Model it off
+   the other parsers in that directory.  You can test the parser
+   with by running, e.g.,
 
-$ python parsers/test_parser.py bbc.BBCParser
+   ```
+   $ python parsers/test_parser.py bbc.BBCParser
+   ```
 
-      which will output a list of URLs to track, and
+   which will output a list of URLs to track, and
 
-$ python parsers/test_parser.py bbc.BBCParser http://www.bbc.co.uk/news/uk-21649494
+   ```
+   $ python parsers/test_parser.py bbc.BBCParser http://www.bbc.co.uk/news/uk-21649494
+   ```
 
-      which will output the text that NewsDiffs would store.
+   which will output the text that NewsDiffs would store.
 
-  (2) Add the parser to 'parsers' in parsers/__init__.py
+2. Add the parser to 'parsers' in parsers/__init__.py
 
 This should cause the scraper to start tracking the site.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 beautifulsoup
 South
 html5lib
+python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,12 @@
-Django <= 1.5
-simplejson
-beautifulsoup4
-beautifulsoup
-South
-html5lib
-python-dateutil
+appdirs==1.4.0
+BeautifulSoup==3.2.1
+beautifulsoup4==4.5.3
+Django==1.5
+html5lib==0.999999999
+packaging==16.8
+pyparsing==2.1.10
+python-dateutil==2.6.0
+simplejson==3.10.0
+six==1.10.0
+South==1.0.2
+webencodings==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ appdirs==1.4.0
 BeautifulSoup==3.2.1
 beautifulsoup4==4.5.3
 Django==1.5
+gunicorn==19.6.0
 html5lib==0.999999999
 packaging==16.8
 pyparsing==2.1.10

--- a/website/frontend/templates/front.html
+++ b/website/frontend/templates/front.html
@@ -5,6 +5,8 @@
 
 {% block content %}
 
+<marquee><blink><h1>NewsDiffs-wh Prototype. (ohai)</h1></blink></marquee>
+
 {% include "find_by_uri.html" %}
 
 <a href="http://newsdiffs.org/browse"><img 

--- a/website/wsgi.py
+++ b/website/wsgi.py
@@ -11,7 +11,7 @@ ROOT_DIR = os.path.dirname(os.path.join(THIS_DIR, '..'))
 sys.path.append(ROOT_DIR)
 # END UGLY COPY FROM mysite.fcgi
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings_dev")
 
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.

--- a/website/wsgi.py
+++ b/website/wsgi.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import os
+import sys
+
+# START UGLY COPY FROM mysite.fcgi
+THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+ROOT_DIR = os.path.dirname(os.path.join(THIS_DIR, '..'))
+
+# Add a custom Python path.
+sys.path.append(ROOT_DIR)
+# END UGLY COPY FROM mysite.fcgi
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "website.settings")
+
+# This application object is used by the development server
+# as well as any WSGI server configured to use this file.
+import django.core.handlers.wsgi
+application = django.core.handlers.wsgi.WSGIHandler()


### PR DESCRIPTION
Beat up the django site so we can deploy it to heroku.  Note, due to #5, this still needs a `heroku config:set DISABLE_COLLECTSTATIC=1` in order to run.

Prototype deployed to: https://newsdiffs-wh.herokuapp.com/