### PR TITLE
Fix Static assets on heroku.

### DIFF
--- a/website/settings_heroku.py
+++ b/website/settings_heroku.py
@@ -88,15 +88,19 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'urls'
 
 INSTALLED_APPS = (
-    'frontend',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'frontend',
 )
 
-STATIC_ROOT = PROJECT_ROOT
+STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')
 STATIC_URL = '/static/'
+
+# Simplified static file serving.
+# # https://warehouse.python.org/project/whitenoise/
+STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
 
 # TODO(awong): Need to create a cache table for this to work.
 #CACHES = {

--- a/website/wsgi.py
+++ b/website/wsgi.py
@@ -20,4 +20,10 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_heroku")
 # This application object is used by the development server
 # as well as any WSGI server configured to use this file.
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
+
 application = get_wsgi_application()
+
+# Use WhiteNoise to server static assets of django server. Makes this work on
+# heroku without another server for static assets.
+application = DjangoWhiteNoise(application)


### PR DESCRIPTION
Correct STATIC_ROOT used by collectstatic to generate the static asset
repository.

Use Django "Whitenoise" to serve up these assets.

fixes #15.